### PR TITLE
set file-magic in extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ long_description = f.read().strip()
 f.close()
 
 install_requires = ['python-dateutil',
-                    'file-magic',
                     'cchardet',
-                    'typing',
+                    'typing'
                     ]
+
 
 setup(name='eml_parser',
       description='Python EML parser library',
@@ -34,5 +34,8 @@ setup(name='eml_parser',
                    'Programming Language :: Python :: Implementation :: CPython',
                    'Topic :: Communications :: Email'
                    ],
+      extras_require = {
+        'file-magic': ["file-magic"]
+      },
       install_requires=install_requires,
       )


### PR DESCRIPTION
Hi, 

As discussed in #13, when python-magic is already used by a project and we want to include _eml_parser_, _file-magic_ (required by _eml_parser_) is installed and incompatibilities happen. 

You managed it in the code, but during the installation process, we still have to install _eml_parser_ and _file-magic_ as a dependency. To avoid issues, we still have to uninstall _file-magic_, uninstall and reinstall _python-magic_.

To make _file-magic_ as an optional dependency,  it can be moved from `install_requires` to  `extras_require` in the _setup.py_ file. 

As a result,  by default, calling `pip install eml_parser` installs without installing _file-magic_ lib. _file-magic_ can be install as dependency with : 
- `pip install eml_parser[file-magic]`
- setting `eml_parser[file-magic]` in _requirements.txt_
- setting `git+https://github.com/GOVCERT-LU/eml_parser.git#egg=project[file-magic]` in _requirements.txt_