### PR TITLE
Adjust typing dependency since backport is not needed for 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ f.close()
 
 install_requires = ['python-dateutil',
                     'cchardet',
-                    'typing'
+                    'typing; python_version < "3.5"'
                     ]
 
 setuptools.setup(name='eml_parser',


### PR DESCRIPTION
Including the typing module in install_requires can occasionally lead to errors/compatibility issues: https://github.com/python/typing/issues/573. 