### PR TITLE
Correct `routing.parserouting()` to handle receiving domains containing the word 'from'

### DIFF
--- a/eml_parser/routing.py
+++ b/eml_parser/routing.py
@@ -169,7 +169,8 @@ def parserouting(line: str) -> typing.Dict[str, typing.Any]:
     # Fixup for "From" in "for" field
     # ie google, do that...
     if out.get('for'):
-        if 'from' in out.get('for', ''):
+        # include spaces in test, otherwise there will be an exception with domains containing "from" in itself
+        if ' from ' in out.get('for', ''):
             temp = re.split(' from ', out['for'])
             out['for'] = temp[0]
             out['from'] = '{} {}'.format(out['from'], ' '.join(temp[1:]))


### PR DESCRIPTION
This commit corrects `routing.parserouting()` to handle domains containing the word 'from' by themselves. It is neccessary to actually check for the existence of `' from '` in the if-statement before grepping for this string to avoid exceptions with domains like `greets-from-example.org`.