### PR TITLE
Handle VISCII encoding lookup errors

### DIFF
--- a/eml_parser/decode.py
+++ b/eml_parser/decode.py
@@ -118,12 +118,13 @@ def decode_string(string: bytes, encoding: typing.Optional[str]) -> str:
 
     if chardet:
         enc = chardet.detect(string)
-        if not(enc['confidence'] is None or enc['encoding'] is None) and not(enc['confidence'] == 1 and enc['encoding'] == 'ascii'):
+        if enc['encoding'] and enc['encoding'].lower() == 'viscii':
+            value = string.decode('ascii', 'replace')
+        elif not(enc['confidence'] is None or enc['encoding'] is None) and not(enc['confidence'] == 1 and enc['encoding'] == 'ascii'):
             try:
                 value = string.decode(enc['encoding'], 'replace')
             except LookupError:
-                if enc['encoding'] == 'VISCII':
-                    value = string.decode('ascii', 'replace')
+                value = string.decode('ascii', 'replace')
 
         else:
             value = string.decode('ascii', 'replace')

--- a/eml_parser/decode.py
+++ b/eml_parser/decode.py
@@ -119,8 +119,9 @@ def decode_string(string: bytes, encoding: typing.Optional[str]) -> str:
     if chardet:
         enc = chardet.detect(string)
         if enc['encoding'] and enc['encoding'].lower() == 'viscii':
+            # chardet may detect the encoding as VISCII but Python doesn't support it
             value = string.decode('ascii', 'replace')
-        elif not(enc['confidence'] is None or enc['encoding'] is None) and not(enc['confidence'] == 1 and enc['encoding'] == 'ascii'):
+        elif not (enc['confidence'] is None or enc['encoding'] is None) and not (enc['confidence'] == 1 and enc['encoding'] == 'ascii'):
             try:
                 value = string.decode(enc['encoding'], 'replace')
             except LookupError:

--- a/eml_parser/decode.py
+++ b/eml_parser/decode.py
@@ -118,8 +118,13 @@ def decode_string(string: bytes, encoding: typing.Optional[str]) -> str:
 
     if chardet:
         enc = chardet.detect(string)
-        if not (enc['confidence'] is None or enc['encoding'] is None) and not (enc['confidence'] == 1 and enc['encoding'] == 'ascii'):
-            value = string.decode(enc['encoding'], 'replace')
+        if not(enc['confidence'] is None or enc['encoding'] is None) and not(enc['confidence'] == 1 and enc['encoding'] == 'ascii'):
+            try:
+                value = string.decode(enc['encoding'], 'replace')
+            except LookupError:
+                if enc['encoding'] == 'VISCII':
+                    value = string.decode('ascii', 'replace')
+
         else:
             value = string.decode('ascii', 'replace')
     else:

--- a/examples/viscii_char_sample
+++ b/examples/viscii_char_sample
@@ -1,0 +1,8 @@
+Incoming bad character: … : |
+
+From: ME <ME@email.com>
+Sent: June-11-21 12:00 AM
+To: YOU <YOU@email.com>
+Subject: test on VISCII
+
+This contains a character triggering VISCII charset


### PR DESCRIPTION
This error turned up while parsing a sample.

Since VISCII is very close to ASCII, might as well decode it as ASCII if VISCII is detected by chardet.