### PR TITLE
Added domain_registered table in result data

### DIFF
--- a/eml_parser/eml_parser.py
+++ b/eml_parser/eml_parser.py
@@ -451,6 +451,7 @@ class EmlParser:
             list_observed_urls_noscheme: typing.List[str] = []
             list_observed_email: typing.Counter[str] = Counter()
             list_observed_dom: typing.Counter[str] = Counter()
+            list_observed_rdom: typing.Counter[str] = Counter()
             list_observed_ip: typing.Counter[str] = Counter()
 
             # If we start directly a findall on 500K+ body we got time and memory issues...
@@ -473,6 +474,7 @@ class EmlParser:
                     valid_domain = self.get_valid_domain_or_ip(match.lower())
                     if valid_domain:
                         list_observed_dom[match.lower()] = 1
+                        list_observed_rdom[self._psl.privatesuffix(match.lower())] = 1
 
                 for ip_regex in (eml_parser.regexes.ipv4_regex, eml_parser.regexes.ipv6_regex):
                     for match in ip_regex.findall(body_slice):
@@ -495,6 +497,7 @@ class EmlParser:
 
                 if list_observed_dom:
                     bodie['domain'] = list(list_observed_dom)
+                    bodie['domain_registered'] = list(list_observed_rdom)
 
                 if list_observed_ip:
                     bodie['ip'] = list(list_observed_ip)


### PR DESCRIPTION
Currently, when analyzing an email with eml_parser, the domains appearing in the body of the email are given in the output, like this:

```
"domain": [
	"b2b.parallels.com",
	"click.parallels.com",
	"coronavirus.data.gov.uk"
],
```

However, a possible issue here is that the full domains are listed, including the subdomains part. This can make the identification of entities and actors complicated if a lot of subdomains are present in the `domain` table.

This commit takes the opportunity to use `publicsuffixlist` (already used in eml_parser) to add a table named `domain_registered` in the data returned by an eml_parser analysis.

The domains in `domain_registered` are the true registered domains, i.e. the "closest" domains to the TLD. Thanks to `publicsuffixlist`, public suffixes like `co.uk` or `co.jp` can be taken into consideration.

Now, the output looks like this:

```
"domain": [
	"b2b.parallels.com",
	"click.parallels.com",
	"coronavirus.data.gov.uk"
],
"domain_registered": [
	"parallels.com",
	"data.gov.uk"
],
```

Do not hesitate to suggest any improvements (especially regarding the name of the table)