### PR TITLE
Address security advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.2]
+### Changes
+- Reduce the time complexity of receive line parsing from quadratic to linear
+- Properly handle HTML entities in extracted URLs
+- Catch the *RecursionError* that can occur when parsing certain headers involving e-mail addresses,
+  and fall back to regex-based parsing
+
 ## [v3.0.1]
 ### Changes
 - Address unlimited recursion issue by raising *RecursionError* if *MULTIPART_RECURSION_LIMIT* has been reached (defaults to 100).

--- a/eml_parser/parser.py
+++ b/eml_parser/parser.py
@@ -11,7 +11,6 @@ import email.message
 import email.policy
 import email.utils
 import hashlib
-import html
 import ipaddress
 import logging
 import os.path
@@ -768,7 +767,9 @@ class EmlParser:
         Returns:
             str: Returns a valid URL, if found in the input string.
         """
-        url = html.unescape(url)  # In case the URL contains HTML entities
+        if '&' in url:
+            url = unescape(url)
+
         if '.' not in url and '[' not in url:
             # if we found a URL like e.g. http://afafasasfasfas; that makes no
             # sense, thus skip it, but include http://[2001:db8::1]
@@ -801,9 +802,6 @@ class EmlParser:
         # filter bogus URLs
         if url.endswith('://'):
             return None
-
-        if '&' in url:
-            url = unescape(url)
 
         return url
 

--- a/eml_parser/parser.py
+++ b/eml_parser/parser.py
@@ -11,6 +11,7 @@ import email.message
 import email.policy
 import email.utils
 import hashlib
+import html
 import ipaddress
 import logging
 import os.path
@@ -496,6 +497,14 @@ class EmlParser:
                     if valid_domain:
                         list_observed_dom[match.lower()] = 1
 
+                # URLs do not necessarily appear as-is in the body, as they may contain escaped entities.
+                # For this reason, we have to extract the domains again from each parsed URL.
+                for url in list_observed_urls + list_observed_urls_noscheme:
+                    for match in eml_parser.regexes.dom_regex.findall(url):
+                        valid_domain = self.get_valid_domain_or_ip(match.lower())
+                        if valid_domain:
+                            list_observed_dom[match.lower()] = 1
+
                 for ip_regex in (eml_parser.regexes.ipv4_regex, eml_parser.regexes.ipv6_regex):
                     for match in ip_regex.findall(body_slice):
                         valid_ip = self.get_valid_domain_or_ip(match.lower())
@@ -759,6 +768,7 @@ class EmlParser:
         Returns:
             str: Returns a valid URL, if found in the input string.
         """
+        url = html.unescape(url)  # In case the URL contains HTML entities
         if '.' not in url and '[' not in url:
             # if we found a URL like e.g. http://afafasasfasfas; that makes no
             # sense, thus skip it, but include http://[2001:db8::1]

--- a/eml_parser/parser.py
+++ b/eml_parser/parser.py
@@ -105,6 +105,15 @@ class CustomPolicy(email.policy.EmailPolicy):
 
             return eml_parser.decode.robust_string2date(value).isoformat()
 
+        elif header in ('sender', 'resent-sender', 'to', 'resent-to', 'cc', 'resent-cc', 'bcc', 'resent-bcc', 'from', 'resent-from', 'reply-to'):
+            try:
+                return super().header_fetch_parse(name, value)
+            except RecursionError:
+                # This can happen when the recursion gets too deep in in the stdlib recursive descent parser.
+                # In this case, the header is certainly pathological. We still try to extract some addresses.
+                m = eml_parser.regexes.email_regex.findall(value)
+                return ', '.join(m)
+
         return super().header_fetch_parse(name, value)
 
 
@@ -172,6 +181,8 @@ class EmlParser:
 
         if self.email_force_tld:
             eml_parser.regexes.email_regex = eml_parser.regexes.email_force_tld_regex
+        else:
+            eml_parser.regexes.email_regex = eml_parser.regexes.email_no_force_tld_regex
 
         # If no whitelisting is required, set to emtpy list
         if 'whiteip' not in self.pconf:

--- a/eml_parser/regexes.py
+++ b/eml_parser/regexes.py
@@ -14,8 +14,9 @@ __license__ = 'AGPL v3+'
 
 # regex compilation
 # W3C HTML5 standard recommended regex for e-mail validation
-email_regex = re.compile(r"""([a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)""", re.MULTILINE)
+email_no_force_tld_regex = re.compile(r"""([a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)""", re.MULTILINE)
 email_force_tld_regex = re.compile(r"""([a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+)""", re.MULTILINE)
+email_regex = email_no_force_tld_regex
 
 # regex for detecting RFC2047 encodings - used from https://dmorgan.info/posts/encoded-word-syntax/
 email_regex_rfc2047 = re.compile(r"""=\?{1}([\w\S]+)\?{1}([B|Q|b|q])\?{1}([\w\S]+)\?{1}=""")

--- a/eml_parser/regexes.py
+++ b/eml_parser/regexes.py
@@ -97,7 +97,6 @@ url_regex_href = re.compile(
 )
 
 date_regex = re.compile(r""";[ \w\s:,+\-()]+$""")
-noparenthesis_regex = re.compile(r"""\([^()]*\)""")
 cleanline_regex = re.compile(r"""(^[;\s]{0,}|[;\s]{0,}$)""")
 
 escape_special_regex_chars = re.compile(r"""([\^$\[\]()+?.])""")

--- a/eml_parser/routing.py
+++ b/eml_parser/routing.py
@@ -10,27 +10,21 @@ import eml_parser.regexes
 def noparenthesis(line: str) -> str:
     """Remove nested parenthesis, until none are present.
 
-    @FIXME rewrite this function.
-
     Args:
         line (str): Input text to search in for parenthesis.
 
     Returns:
         str: Return a string with all parenthesis removed.
     """
-    # check empty string
-    if not line:
-        return line
-
-    line_ = line
-
-    while True:
-        lline = line_
-        line_ = eml_parser.regexes.noparenthesis_regex.sub('', line_)
-        if lline == line_:
-            break
-
-    return line_
+    fragments: list[list[str]] = [[]]
+    for ch in line:
+        if ch == '(':
+            fragments.append([ch])
+        else:
+            fragments[-1].append(ch)
+        if ch == ')' and len(fragments) > 1:
+            fragments.pop()
+    return ''.join([ch for w in fragments for ch in w])
 
 
 def cleanline(line: str) -> str:

--- a/eml_parser/routing.py
+++ b/eml_parser/routing.py
@@ -8,13 +8,14 @@ import eml_parser.regexes
 
 
 def noparenthesis(line: str) -> str:
-    """Remove nested parenthesis, until none are present.
+    """Remove nested parentheses, until no pairs of matching parentyheses are present.
 
     Args:
-        line (str): Input text to search in for parenthesis.
+        line (str): Input text to search in for parentheses.
 
     Returns:
-        str: Return a string with all parenthesis removed.
+        str: Return a string with all text in matching parentheses removed. For example,
+        noparenthesis('a((b)c(d') == 'a(c(d'
     """
     fragments: list[list[str]] = [[]]
     for ch in line:
@@ -24,7 +25,7 @@ def noparenthesis(line: str) -> str:
             fragments[-1].append(ch)
         if ch == ')' and len(fragments) > 1:
             fragments.pop()
-    return ''.join([ch for w in fragments for ch in w])
+    return ''.join(ch for w in fragments for ch in w)
 
 
 def cleanline(line: str) -> str:

--- a/tests/test_emlparser.py
+++ b/tests/test_emlparser.py
@@ -495,3 +495,28 @@ Lorem ipsüm dolor sit amét, consectetur 10$ + 5€ adipiscing elit. Praesent f
             output_3 = ep.decode_email_bytes(fhdl.read())
 
         assert 'message-id' not in output_3['header']['header']
+
+    def test_parse_urls_with_html_entities(self) -> None:
+        phish_eml = (
+            b'From: security@bank-of-examples.com\r\n'
+            b'To: victim@example.org\r\n'
+            b'Subject: Urgent: Verify Your Account\r\n'
+            b'Date: Mon, 2 May 2026 10:00:00 +0000\r\n'
+            b'Content-Type: text/html; charset="utf-8"\r\n'
+            b'\r\n'
+            b'<html><body>\r\n'
+            b'<p>Dear customer,</p>\r\n'
+            b'<p>Please verify your account at\r\n'
+            b'<a href="https:&#47;&#47;phishing&#46;example&#46;com/verify?id=ABCD1234">click here</a></p>\r\n'
+            b'<img src="other.example&#46;com?something&amp;blub">\r\n'
+            b'Send us an <a href="mailto&#58;scammer@example&#46;com">e-mail</a>!\r\n'
+            b'<p>Bank of Examples Security</p>\r\n'
+            b'</body></html>\r\n'
+        )
+        ep = eml_parser.EmlParser(include_raw_body=True, include_www=True, include_href=True)
+        result = ep.decode_email_bytes(phish_eml)
+        body = result['body'][0]
+
+        assert body['uri'] == ['https://phishing.example.com/verify?id=ABCD1234']
+        assert set(body['uri_noscheme']) == {'other.example.com?something&blub', 'mailto:scammer@example.com'}
+        assert set(body['domain']) == {'phishing.example.com', 'other.example.com', 'example.com'}

--- a/tests/test_pathological_headers.py
+++ b/tests/test_pathological_headers.py
@@ -1,0 +1,16 @@
+import pytest
+
+import eml_parser.parser
+
+
+class TestPathologicalHeaders:
+    @pytest.mark.parametrize('header,count', [('cc', 500), ('From', 500), ('resent-sender', 500), ('Sender', 500)])
+    def test_many_open_parentheses(self, header: str, count: int) -> None:
+        parens = b'(' * count
+        sample = header.encode() + b': ' + parens + b', c@c' + b', Foo Bar <d@d> ' + parens
+        ep = eml_parser.EmlParser()
+        data = ep.decode_email_bytes(sample)
+        header_name = header.lower()
+        assert data['header']['header'][header_name] == ['c@c, d@d']
+        if header_name in ('to', 'cc'):
+            assert data['header'][header_name] == ['c@c', 'd@d']

--- a/tests/test_pathological_headers.py
+++ b/tests/test_pathological_headers.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 import eml_parser.parser
@@ -14,3 +16,15 @@ class TestPathologicalHeaders:
         assert data['header']['header'][header_name] == ['c@c, d@d']
         if header_name in ('to', 'cc'):
             assert data['header'][header_name] == ['c@c', 'd@d']
+
+    def test_many_parentheses_in_received_header(self) -> None:
+        count = 50000
+        start = time.monotonic()
+        open_parens = b'(' * count
+        closed_parens = b')' * count
+        sample = b'Received: from ' + open_parens + b', a.a, ' + closed_parens
+        eml_parser.EmlParser.MULTIPART_RECURSION_LIMIT = 100
+        ep = eml_parser.EmlParser()
+        ep.decode_email_bytes(sample)
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.5

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -12,10 +12,15 @@ samples_dir = parent_dir / 'samples'
 class TestRouting:
     def test_noparenthesis(self) -> None:
         test_input = {
+            ' test ': ' test ',
             '(test)': '',
             '((test))': '',
             '(((test) (bla)))': '',
             '(test) foo': ' foo',
+            'asd (foo (test)(() foo': 'asd (foo ( foo',
+            'foo (test) )()foo)': 'foo  )foo)',
+            '(asd)(((((': '(((((',
+            '))))(asd)': '))))',
         }
 
         for test, expected_result in test_input.items():


### PR DESCRIPTION
This change aims to address the following security advisories:

1. [URL extraction bypass via HTML entity encoding in clean_found_uri validation order](https://github.com/GOVCERT-LU/eml_parser/security/advisories/GHSA-fxgq-9m89-cxj9) is addressed by calling `html_unescape` on URLs in `clean_found_uri()`. As this means that an extracted URL might no longer occur as-is in the body text, I also added a new round of domain name extraction for all observed (i.e., unescaped) URLs.
2. [Recursion DoS in headeremail2list() via deeply nested CFWS in any address header](https://github.com/GOVCERT-LU/eml_parser/security/advisories/GHSA-m66c-fw79-6359) is addressed by catching the RecursionError and falling back to a regexp-based email-address extractor.
3. [Quadratic complexity DoS in routing.noparenthesis() via deeply nested parens in Received headers](https://github.com/GOVCERT-LU/eml_parser/security/advisories/GHSA-g7gc-gmgp-wgqg) is addressed by providing a linear-time implementation of the `noparenthesis()` function.
